### PR TITLE
Fix form field width on Posts page - 50vw and centered on screen

### DIFF
--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -1,14 +1,25 @@
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
+import { Box } from '@mui/system';
 
-const PostForm = ({handleSubmit, handleChange}) => {
-
-  return(
-    <form className="post-form" onSubmit={handleSubmit}>
-      <TextField className="user-form-input" type="text" label="New Post" variant="outlined" name="content" onChange={handleChange} />
-      <Button type="submit" variant="contained">Submit</Button>
-    </form>
-  )
-}
+const PostForm = ({ handleSubmit, handleChange }) => {
+  return (
+    <Box sx={{ width: '50vw', margin: '0 auto' }}>
+      <form className='post-form' onSubmit={handleSubmit}>
+        <TextField
+          className='user-form-input'
+          type='text'
+          label='New Post'
+          variant='outlined'
+          name='content'
+          onChange={handleChange}
+        />
+        <Button sx={{ marginTop: '2em' }} type='submit' variant='contained'>
+          Submit
+        </Button>
+      </form>
+    </Box>
+  );
+};
 
 export default PostForm;


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/43435750/165433758-dd8f3191-573e-4afe-b9d0-d53e0fcba910.PNG)

The form field on Posts page has been set at 50vw with a margin: auto, 0 to center the field. Previously the field spanned 100vw