### PR TITLE
fix: display the loggedIn user's profile

### DIFF
--- a/src/components/profile/Profile.js
+++ b/src/components/profile/Profile.js
@@ -17,12 +17,12 @@ const Profile = () => {
   let isOwner = false
 
   useEffect(() => {
-    setUserDisplayed(location.state.user)
-  }, [location])
-
-  if (userLoggedIn.id === userDisplayed.id) {
-    isOwner = true
-  }
+    if (location.state) {
+      setUserDisplayed(location.state.user)
+    } else {
+      setUserDisplayed(userLoggedIn)
+    }
+  }, [location, userLoggedIn])
 
   const handleSubmit = (newInfo) => {
     const reqBody = {


### PR DESCRIPTION
display the loggedIn user's profile when visiting the /profile route directly